### PR TITLE
TASK: Neos.Form 4.0 compatibility

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -10,7 +10,6 @@ Neos:
             renderingOptions:
               templatePathPattern: 'resource://Wegmeister.Recaptcha/Private/Form/Captcha.html'
               validationErrorTranslationPackage: Wegmeister.Recaptcha
-              translationPackage: Wegmeister.Recaptcha
         validatorPresets:
           'Wegmeister.Recaptcha:IsValid':
             implementationClassName: Wegmeister\Recaptcha\Validation\Validator\IsValidValidator

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ renderables:
           tabindex: 0
         # optionally change the translationPackage
         # if you want to adjust the error message
-        renderingOptions:
-          translationPackage: 'Wegmeister.Recaptcha'
+        #renderingOptions:
+        #  validationErrorTranslationPackage: 'Wegmeister.Recaptcha'
         validators:
           -
             identifier: 'Wegmeister.Recaptcha:IsValid'

--- a/Resources/Private/Translations/de/Form.xlf
+++ b/Resources/Private/Translations/de/Form.xlf
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="TYPO3.Flow" source-language="en" datatype="plaintext" target-language="de">
-    <body>
-      <!-- No translations here for now as Captcha is almost always Captcha in all Languages -->
-    </body>
-  </file>
-</xliff>

--- a/Resources/Private/Translations/de/ValidationErrors.xlf
+++ b/Resources/Private/Translations/de/ValidationErrors.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="TYPO3.Flow" source-language="en" datatype="plaintext" target-language="de">
+  <file original="" product-name="Wegweiser.Recaptcha" source-language="en" datatype="plaintext" target-language="de">
     <body>
       <!-- CaptchaValidator -->
       <trans-unit id="1450180930" xml:space="preserve" approved="yes">

--- a/Resources/Private/Translations/en/Form.xlf
+++ b/Resources/Private/Translations/en/Form.xlf
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" product-name="TYPO3.Flow" source-language="en" datatype="plaintext">
-		<body>
-      <!-- No translations here for now as Captcha is almost always Captcha in all Languages -->
-		</body>
-	</file>
-</xliff>

--- a/Resources/Private/Translations/en/ValidationErrors.xlf
+++ b/Resources/Private/Translations/en/ValidationErrors.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" product-name="TYPO3.Flow" source-language="en" datatype="plaintext">
+	<file original="" product-name="Wegweiser.Recaptcha" source-language="en" datatype="plaintext">
 		<body>
 			<!-- CaptchaValidator -->
 			<trans-unit id="1450180930" xml:space="preserve">

--- a/Resources/Private/Translations/nl/Form.xlf
+++ b/Resources/Private/Translations/nl/Form.xlf
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" product-name="TYPO3.Flow" source-language="en" datatype="plaintext">
-		<body>
-      <!-- No translations here for now as Captcha is almost always Captcha in all Languages -->
-		</body>
-	</file>
-</xliff>

--- a/Resources/Private/Translations/nl/ValidationErrors.xlf
+++ b/Resources/Private/Translations/nl/ValidationErrors.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" product-name="TYPO3.Flow" source-language="en" datatype="plaintext">
+	<file original="" product-name="Wegweiser.Recaptcha" source-language="en" datatype="plaintext">
 		<body>
 			<!-- CaptchaValidator -->
 			<trans-unit id="1450180930" xml:space="preserve">

--- a/Resources/Private/Translations/tr/Form.xlf
+++ b/Resources/Private/Translations/tr/Form.xlf
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" product-name="TYPO3.Flow" source-language="en" datatype="plaintext">
-		<body>
-      <!-- No translations here for now as Captcha is almost always Captcha in all Languages -->
-		</body>
-	</file>
-</xliff>

--- a/Resources/Private/Translations/tr/ValidationErrors.xlf
+++ b/Resources/Private/Translations/tr/ValidationErrors.xlf
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file original="" product-name="TYPO3.Flow" source-language="en" datatype="plaintext" target-language="tr-TR">
+  <file original="" product-name="Wegweiser.Recaptcha" source-language="en" datatype="plaintext" target-language="tr-TR">
     <body>
       <!-- CaptchaValidator -->
       <trans-unit id="1450180930" xml:space="preserve" approved="yes">

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,11 @@
 {
     "name": "wegmeister/recaptcha",
-    "type": "neos-plugin",
+    "type": "neos-package",
     "license": "CC-BY-3.0",
-    "description": "Neos-Plugin to integrate Google's Recaptcha into Forms",
+    "description": "Form Element for the Flow Form Framework integrating Google's Recaptcha",
     "require": {
         "google/recaptcha": "~1.1",
-        "neos/form": "*",
-        "neos/flow": "*"
+        "neos/form": "^4.0"
     },
     "autoload": {
         "psr-4": {
@@ -14,6 +13,9 @@
         }
     },
     "extra": {
+        "neos": {
+            "package-key": "Wegmeister.Recaptcha"
+        },
         "applied-flow-migrations": [
             "TYPO3.FLOW3-201201261636",
             "TYPO3.Fluid-201205031303",


### PR DESCRIPTION
* Remove unused `Main.xlf` files
* Unset `translationPackage` rendering option to prevent rendering
  errors with default `Field` layout
* Composer type `neos-plugin` => `neos-package` as this package does
  not contain any plugins
* Adjust composer dependencies according to Semantic Versioning