### PR TITLE
Typo in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ renderables:
     identifier: page-one
     renderables:
       -
-        type: 'Wegmeister.Recaptcha:Captcha2'
+        type: 'Wegmeister.Recaptcha:CaptchaV2'
         identifier: captcha
         label: Captcha
         properties:


### PR DESCRIPTION
It seems the V was missing in 'Wegmeister.Recaptcha:CaptchaV2'