### PR TITLE
Feature/curl proxy option

### DIFF
--- a/Classes/FormElements/Recaptcha.php
+++ b/Classes/FormElements/Recaptcha.php
@@ -20,6 +20,8 @@ namespace Wegmeister\Recaptcha\FormElements;
 use Neos\Error\Messages\Error;
 use Neos\Form\Core\Model\AbstractFormElement;
 use Neos\Form\Core\Runtime\FormRuntime;
+use ReCaptcha\RequestMethod;
+use ReCaptcha\RequestMethod\CurlPost;
 
 /**
  * This is the implementation class of the Recaptcha.
@@ -71,36 +73,39 @@ class Recaptcha extends AbstractFormElement
             return;
         }
 
-        $requestMethodString = strtolower($this->settings['requestMethod']);
-        if ($requestMethodString === 'curl') {
-            $requestMethod = new \ReCaptcha\RequestMethod\CurlPost();
-        } elseif ($requestMethodString === 'socket') {
-            $requestMethod = new \ReCaptcha\RequestMethod\SocketPost();
+        $requestMethodString = $this->settings['requestMethod'];
+
+        if (self::isReCaptchaRequestClass($requestMethodString)) {
+            $requestMethod = new $requestMethodString();
         } else {
-            $requestMethod = new \ReCaptcha\RequestMethod\Post();
+            $requestMethod = match (strtolower($requestMethodString)) {
+                'curl' => new \ReCaptcha\RequestMethod\CurlPost(),
+                'socket' => new \ReCaptcha\RequestMethod\SocketPost(),
+                default => new \ReCaptcha\RequestMethod\Post(),
+            };
         }
 
         $properties = $this->getProperties();
-        $recaptcha = new \ReCaptcha\ReCaptcha($properties['secretKey'], $requestMethod);
+        $recaptcha  = new \ReCaptcha\ReCaptcha($properties['secretKey'], $requestMethod);
 
         if (!empty($properties['expectedHostname'])) {
             $recaptcha->setExpectedHostname($properties['expectedHostname']);
         }
-        /**  
+        /**
          * If one of the following three is set, it is the V3 Captcha.
-         * Action and Threshold can't be empty due to validators, we still 
+         * Action and Threshold can't be empty due to validators, we still
          * need to look if they are set because it could be the V2 Captcha.
          */
-        if(isset($properties['action'])) {
+        if (isset($properties['action'])) {
             $recaptcha->setExpectedAction($properties['action']);
         }
-        if(isset($properties['threshold'])) {
+        if (isset($properties['threshold'])) {
             $recaptcha->setScoreThreshold($properties['threshold']);
         }
         /**
          * Optional
          */
-        if(isset($properties['timeout'])) {
+        if (isset($properties['timeout'])) {
             $recaptcha->setChallengeTimeout($properties['timeout']);
         }
 
@@ -108,7 +113,7 @@ class Recaptcha extends AbstractFormElement
 
         if ($resp->isSuccess() === false) {
 
-            $processingRule = 
+            $processingRule =
                 $this
                     ->getRootForm()
                     ->getProcessingRule($this->getIdentifier());
@@ -118,7 +123,7 @@ class Recaptcha extends AbstractFormElement
              * The Error 'Please check the box "I am not a robot" and try again.'
              * Is not suitable for the V3 Captcha.
              */
-            if(isset($properties['action'])) {
+            if (isset($properties['action'])) {
                 $processingRule
                     ->getProcessingMessages()
                     ->addError(
@@ -138,5 +143,15 @@ class Recaptcha extends AbstractFormElement
                     );
             }
         }
+    }
+
+    /**
+     * @param string $className
+     *
+     * @return bool
+     */
+    protected static function isReCaptchaRequestClass(string $className)
+    {
+        return class_exists($className) && in_array('ReCaptcha\RequestMethod', class_implements($className), true);
     }
 }

--- a/Classes/RequestMethod/CurlPostWithProxy.php
+++ b/Classes/RequestMethod/CurlPostWithProxy.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Wegmeister\Recaptcha\RequestMethod;
+
+use ReCaptcha\ReCaptcha;
+use ReCaptcha\RequestMethod;
+use ReCaptcha\RequestMethod\Curl;
+use ReCaptcha\RequestParameters;
+
+class CurlPostWithProxy implements RequestMethod
+{
+    /**
+     * Curl connection to the reCAPTCHA service
+     * @var Curl
+     */
+    private $curl;
+
+    /**
+     * URL for reCAPTCHA siteverify API
+     * @var string
+     */
+    private $siteVerifyUrl;
+
+    /**
+     * Only needed if you want to override the defaults
+     *
+     * @param Curl $curl Curl resource
+     * @param string $siteVerifyUrl URL for reCAPTCHA siteverify API
+     */
+    public function __construct(Curl $curl = null, $siteVerifyUrl = null)
+    {
+        $this->curl = (is_null($curl)) ? new Curl() : $curl;
+        $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : $siteVerifyUrl;
+    }
+
+    /**
+     * Submit the cURL request with the specified parameters.
+     *
+     * @param RequestParameters $params Request parameters
+     * @return string Body of the reCAPTCHA response
+     */
+    public function submit(RequestParameters $params)
+    {
+        $handle = $this->curl->init($this->siteVerifyUrl);
+
+        $options = array(
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $params->toQueryString(),
+            CURLOPT_HTTPHEADER => array(
+                'Content-Type: application/x-www-form-urlencoded'
+            ),
+            CURLINFO_HEADER_OUT => false,
+            CURLOPT_HEADER => false,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_SSL_VERIFYPEER => true,
+        );
+
+        if (isset($_SERVER["http_proxy"])) {
+            $proxy = trim(
+                preg_replace('/^http\:\/\//i', '', $_SERVER["http_proxy"]),
+                '/'
+            );
+            $proxy = explode(':', $proxy);
+            $options[CURLOPT_RETURNTRANSFER] = 1;
+            $options[CURLOPT_PROXY] = $proxy[0];
+            $options[CURLOPT_PROXYPORT] = $proxy[1];
+        }
+
+        $this->curl->setoptArray($handle, $options);
+
+        $response = $this->curl->exec($handle);
+        $this->curl->close($handle);
+
+        if ($response !== false) {
+            return $response;
+        }
+
+        return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
+    }
+}

--- a/Classes/RequestMethod/CurlPostWithProxy.php
+++ b/Classes/RequestMethod/CurlPostWithProxy.php
@@ -6,30 +6,57 @@ use ReCaptcha\ReCaptcha;
 use ReCaptcha\RequestMethod;
 use ReCaptcha\RequestMethod\Curl;
 use ReCaptcha\RequestParameters;
+use Neos\Flow\Annotations as Flow;
 
+/**
+ * Copy of \ReCaptcha\RequestMethod\CurlPost()
+ * adding functionality for curl to work with a http proxy
+ */
 class CurlPostWithProxy implements RequestMethod
 {
     /**
      * Curl connection to the reCAPTCHA service
+     *
      * @var Curl
      */
     private $curl;
 
     /**
      * URL for reCAPTCHA siteverify API
+     *
      * @var string
      */
     private $siteVerifyUrl;
 
     /**
+     * Recaptcha settings
+     *
+     * @var array
+     */
+    protected $settings;
+
+    /**
+     * Inject the settings
+     *
+     * @param array $settings The settings to inject.
+     *
+     * @return void
+     */
+    public function injectSettings(array $settings)
+    {
+        $this->settings = $settings['proxy'] ?? [];
+    }
+
+
+    /**
      * Only needed if you want to override the defaults
      *
-     * @param Curl $curl Curl resource
+     * @param Curl   $curl          Curl resource
      * @param string $siteVerifyUrl URL for reCAPTCHA siteverify API
      */
     public function __construct(Curl $curl = null, $siteVerifyUrl = null)
     {
-        $this->curl = (is_null($curl)) ? new Curl() : $curl;
+        $this->curl          = (is_null($curl)) ? new Curl() : $curl;
         $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : $siteVerifyUrl;
     }
 
@@ -37,33 +64,33 @@ class CurlPostWithProxy implements RequestMethod
      * Submit the cURL request with the specified parameters.
      *
      * @param RequestParameters $params Request parameters
+     *
      * @return string Body of the reCAPTCHA response
      */
     public function submit(RequestParameters $params)
     {
         $handle = $this->curl->init($this->siteVerifyUrl);
 
-        $options = array(
-            CURLOPT_POST => true,
-            CURLOPT_POSTFIELDS => $params->toQueryString(),
-            CURLOPT_HTTPHEADER => array(
-                'Content-Type: application/x-www-form-urlencoded'
-            ),
-            CURLINFO_HEADER_OUT => false,
-            CURLOPT_HEADER => false,
+        $options = [
+            CURLOPT_POST           => true,
+            CURLOPT_POSTFIELDS     => $params->toQueryString(),
+            CURLOPT_HTTPHEADER     => [
+                'Content-Type: application/x-www-form-urlencoded',
+            ],
+            CURLINFO_HEADER_OUT    => false,
+            CURLOPT_HEADER         => false,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_SSL_VERIFYPEER => true,
-        );
+        ];
 
-        if (isset($_SERVER["http_proxy"])) {
-            $proxy = trim(
-                preg_replace('/^http\:\/\//i', '', $_SERVER["http_proxy"]),
-                '/'
-            );
-            $proxy = explode(':', $proxy);
+        if (isset($this->settings['httpProxy']) && !empty($this->settings['httpProxy'])) {
+            $httpProxy = $this->settings['httpProxy'];
+            $this->emitHttpProxyRetrieved($httpProxy);
+
+            $proxy                           = explode(':', $httpProxy);
             $options[CURLOPT_RETURNTRANSFER] = 1;
-            $options[CURLOPT_PROXY] = $proxy[0];
-            $options[CURLOPT_PROXYPORT] = $proxy[1];
+            $options[CURLOPT_PROXY]          = $proxy[0];
+            $options[CURLOPT_PROXYPORT]      = $proxy[1];
         }
 
         $this->curl->setoptArray($handle, $options);
@@ -75,6 +102,16 @@ class CurlPostWithProxy implements RequestMethod
             return $response;
         }
 
-        return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
+        return '{"success": false, "error-codes": ["' . ReCaptcha::E_CONNECTION_FAILED . '"]}';
+    }
+
+    /**
+     * @param string $httpProxy
+     *
+     * @return void
+     * @Flow\Signal
+     */
+    protected function emitHttpProxyRetrieved(string &$httpProxy)
+    {
     }
 }

--- a/Classes/RequestMethod/CurlPostWithProxy.php
+++ b/Classes/RequestMethod/CurlPostWithProxy.php
@@ -44,7 +44,10 @@ class CurlPostWithProxy implements RequestMethod
      */
     public function injectSettings(array $settings)
     {
-        $this->settings = $settings['proxy'] ?? [];
+        if (empty($this->settings['httpProxy'])) {
+            throw new \Exception("Missing configuration, please add the following settings: 'Wegmeister.Recaptcha.httpProxy'");
+        }
+        $this->settings = $settings;
     }
 
 
@@ -83,15 +86,13 @@ class CurlPostWithProxy implements RequestMethod
             CURLOPT_SSL_VERIFYPEER => true,
         ];
 
-        if (isset($this->settings['httpProxy']) && !empty($this->settings['httpProxy'])) {
-            $httpProxy = $this->settings['httpProxy'];
-            $this->emitHttpProxyRetrieved($httpProxy);
+        $httpProxy = $this->settings['httpProxy'];
+        $this->emitHttpProxyRetrieved($httpProxy);
 
-            $proxy                           = explode(':', $httpProxy);
-            $options[CURLOPT_RETURNTRANSFER] = 1;
-            $options[CURLOPT_PROXY]          = $proxy[0];
-            $options[CURLOPT_PROXYPORT]      = $proxy[1];
-        }
+        $proxy                           = explode(':', $httpProxy);
+        $options[CURLOPT_RETURNTRANSFER] = 1;
+        $options[CURLOPT_PROXY]          = $proxy[0];
+        $options[CURLOPT_PROXYPORT]      = $proxy[1];
 
         $this->curl->setoptArray($handle, $options);
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -39,3 +39,7 @@ Wegmeister:
     # Available request methods: file_get_contents, curl, socket.
     # If an invalid request method is applied, file_get_contents will be used.
     requestMethod: 'file_get_contents'
+
+    proxy:
+      # in the format of <proxy-hostname>:<port>
+      httpProxy: ''

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -39,7 +39,5 @@ Wegmeister:
     # Available request methods: file_get_contents, curl, socket.
     # If an invalid request method is applied, file_get_contents will be used.
     requestMethod: 'file_get_contents'
-
-    proxy:
-      # in the format of <proxy-hostname>:<port>
-      httpProxy: ''
+    # in the format of <proxy-hostname>:<port>
+    httpProxy: ''


### PR DESCRIPTION
**What I did**
- Allowing the package to work in a server environment using a http proxy.
- Allowing a custom request method.

**How I did it**
I added a copy (CurlPostWithProxy) of \ReCaptcha\RequestMethod\CurlPost allowing to use a http proxy with the curl request. Additionally I added a Slot to allow to modify the proxy value from loaded from the settings, in my case I use this to retrieve the http proxy value from the $_SERVER variable. I also check if the requestMethod option is a existing class and if so use it as the request method.

**How to verify it**
The following settings are required to set the http proxy options in the curl request:
```
Wegmeister:
  Recaptcha:
    requestMethod: 'Wegmeister\Recaptcha\RequestMethod\CurlPostWithProxy'
    httpProxy: 'yourdomain.com:1234'
``` 
**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed (I didn't find any existing tests so I skipped this)
- [ ] The PR keeps backwards compatibility for older versions of Neos if possible.
        "neos/neos": "^8.3"
        "php": ">=8"
