### PR TITLE
TASK: Neos Form 6 Compatibility

### DIFF
--- a/Resources/Private/Fusion/Elements/Captcha.fusion
+++ b/Resources/Private/Fusion/Elements/Captcha.fusion
@@ -1,3 +1,4 @@
+// TODO 9.0 migration: Line 8: !! node.context.dimensions is removed in Neos 9.0. You can get node DimensionSpacePoints via node.dimensionSpacePoints now or use the `Neos.Dimension.*` helper.
 prototype(Wegmeister.Recaptcha:Captcha.Definition) < prototype(Neos.Form.Builder:FormElement.Definition) {
     formElementType = 'Wegmeister.Recaptcha:Captcha'
 

--- a/Resources/Private/Fusion/Elements/CaptchaV2.fusion
+++ b/Resources/Private/Fusion/Elements/CaptchaV2.fusion
@@ -1,3 +1,4 @@
+// TODO 9.0 migration: Line 15: !! node.context.dimensions is removed in Neos 9.0. You can get node DimensionSpacePoints via node.dimensionSpacePoints now or use the `Neos.Dimension.*` helper.
 prototype(Wegmeister.Recaptcha:CaptchaV2.Definition) < prototype(Neos.Form.Builder:FormElement.Definition) {
     formElementType = 'Wegmeister.Recaptcha:CaptchaV2'
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Form Element for the Flow Form Framework integrating Google's Recaptcha",
     "require": {
         "google/recaptcha": "^1.2",
-        "neos/form": "^4.0 || ^5.0.9",
+        "neos/form": "^4.0 || ^5.0.9 || ^6.0",
         "php": "^8.0"
     },
     "autoload": {


### PR DESCRIPTION
**What I did**
I upgraded the package with rector to make it possible to use with Neos Form 6.

**How I did it**
I used rector from neos.

**How to verify it**
I used this package in an Neos 9 instance and it worked fine, even if it has the open TODOS.

**Checklist**

- [ ] Can someone resolve the open TODOs?
- [ ] The PR keeps backwards compatibility for older versions of Neos if possible.-> I dont think so is possible
